### PR TITLE
Forward-declare vc-find-root

### DIFF
--- a/eshell-toggle.el
+++ b/eshell-toggle.el
@@ -116,6 +116,8 @@
                 win))
 	 (window-list)))
 
+(declare-function vc-find-root "vc-hooks")
+
 (defun eshell-toggle-get-git-directory (dir)
   "Returns directory path of git project root directory, otherwise return nil."
   (require 'vc)


### PR DESCRIPTION
Without a top-level require, we need this for proper byte-compiler treatment.


----

#