### PR TITLE
Remove needless quotes

### DIFF
--- a/eshell-toggle.el
+++ b/eshell-toggle.el
@@ -55,10 +55,10 @@
 (defcustom eshell-toggle-window-side
   'below
   "Eshell-toggle buffer position.  See `split-window'."
-  :type '(choice (const 'above)
-                 (const 'below)
-                 (const 'left)
-                 (const 'right))
+  :type '(choice (const above)
+                 (const below)
+                 (const left)
+                 (const right))
   :group 'eshell-toggle)
 
 (defcustom eshell-toggle-default-directory


### PR DESCRIPTION
Those values are already quoted so they are unnecessary. This also fixes the following byte-compile warning.

```
eshell-toggle.el:55:12: Warning: defcustom for ‘eshell-toggle-window-side’ has
    syntactically odd type ‘'(choice (const 'above) (const 'below) (const
    'left) (const 'right))’
```