### PR TITLE
Support in-built Project.el

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ or using use-package and quelpa:
     (use-package eshell-toggle
       :custom
       (eshell-toggle-size-fraction 3)
-      (eshell-toggle-use-projectile-root t)
+      (eshell-toggle-use-projectile-root t) ;; for projectile
+      ;; (eshell-toggle-use-project-root t) ;; for in-built project.el
       (eshell-toggle-run-command nil)
       (eshell-toggle-init-function #'eshell-toggle-init-ansi-term)
       :quelpa
@@ -26,7 +27,8 @@ or using use-package and quelpa:
 
 - `eshell-toggle-default-directory` Default directory to open eshell at if buffer has no associated file;
 - `eshell-toggle-name-separator` String to separate directory paths when giving a name to buffer.
-- `eshell-toggle-use-projectile-root` If not nil eshell-toggle will try to use projectile to open eshell at project root.
+- `eshell-toggle-use-projectile-root` If not nil eshell-toggle will try to use `projectile` to open eshell at project root.
+- `eshell-toggle-use-project-root` If not nil eshell-toggle will try to use in-built `project.el` to open eshell at project root.
 
 - `eshell-toggle-run-command` - command to run in a new shell.
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ or using use-package and quelpa:
     (use-package eshell-toggle
       :custom
       (eshell-toggle-size-fraction 3)
-      (eshell-toggle-use-projectile-root t) ;; for projectile
-      ;; (eshell-toggle-use-project-root t) ;; for in-built project.el
+      (eshell-toggle-find-project-root-package t) ;; for projectile
+      ;;(eshell-toggle-find-project-root-package 'projectile) ;; for projectile
+      ;; (eshell-toggle-use-projectile-root 'project) ;; for in-built project.el
       (eshell-toggle-run-command nil)
       (eshell-toggle-init-function #'eshell-toggle-init-ansi-term)
       :quelpa
@@ -27,8 +28,8 @@ or using use-package and quelpa:
 
 - `eshell-toggle-default-directory` Default directory to open eshell at if buffer has no associated file;
 - `eshell-toggle-name-separator` String to separate directory paths when giving a name to buffer.
-- `eshell-toggle-use-projectile-root` If not nil eshell-toggle will try to use `projectile` to open eshell at project root.
-- `eshell-toggle-use-project-root` If not nil eshell-toggle will try to use in-built `project.el` to open eshell at project root.
+- `eshell-toggle-use-projectile-root` is obsolete since 0.10.1, use the following `eshell-toggle-find-project-root-package` instead.
+- `eshell-toggle-find-project-root-package`  If set to `'project` it tries to use the built-in `project` to open an eshell at project root, if set to `'projectile` or `t` it uses `projectile`, and if set to nil it detects the current directory.
 
 - `eshell-toggle-run-command` - command to run in a new shell.
 

--- a/eshell-toggle.el
+++ b/eshell-toggle.el
@@ -74,6 +74,13 @@
                  (const :tag "Enabled" t))
   :group 'eshell-toggle)
 
+(defcustom eshell-toggle-use-project-root
+  nil
+  "Open eshell at project.el's project root if not nil."
+  :type '(choice (const :tag "Disabled" nil)
+                 (const :tag "Enabled" t))
+  :group 'eshell-toggle)
+
 (defcustom eshell-toggle-name-separator
   ":"
   "String to separate directory paths when giving a name to buffer."
@@ -127,21 +134,32 @@
        (condition-case nil
            (projectile-project-root)
          (error nil)))
+   (if eshell-toggle-use-project-root
+       (condition-case nil
+           (project-root (project-current))
+         (error nil)))
    (if eshell-toggle-use-git-root
        (condition-case nil
-	   (eshell-toggle-get-git-directory default-directory)
+           (eshell-toggle-get-git-directory default-directory)
          (error nil)))
    eshell-toggle-default-directory
    default-directory))
 
 (defun eshell-toggle--make-buffer-name ()
   "Generate toggle buffer name."
-  (if eshell-toggle-use-projectile-root
-      (concat "*et" eshell-toggle-name-separator (projectile-project-name) "*")
-    (let* ((dir (eshell-toggle--get-directory))
-           (name (string-join (split-string dir "/") eshell-toggle-name-separator))
-           (buf-name (concat "*et" name "*")))
-      buf-name)))
+  (or
+   (if eshell-toggle-use-projectile-root
+       (concat "*et" eshell-toggle-name-separator (projectile-project-name) "*")
+     (let* ((dir (eshell-toggle--get-directory))
+            (name (string-join (split-string dir "/") eshell-toggle-name-separator))
+            (buf-name (concat "*et" name "*")))
+       buf-name))
+   (if eshell-toggle-use-project-root
+       (concat "*et" eshell-toggle-name-separator (project-name (project-current)) "*")
+     (let* ((dir (eshell-toggle--get-directory))
+            (name (string-join (split-string dir "/") eshell-toggle-name-separator))
+            (buf-name (concat "*et" name "*")))
+       buf-name))))
 
 (defun eshell-toggle-init-eshell (dir)
   "Init `eshell' buffer with DIR."


### PR DESCRIPTION
@4DA please review.

Introduce `eshell-toggle-find-project-root-package'.

Make `eshell-toggle-use-project-root' obsolete.

Make sure this change does not break users current config, so use `defalias'
Fix warning.
update README.